### PR TITLE
[#54] Refactor: naver full-scan scheduler 적용 및 기존 daily-scan 삭제

### DIFF
--- a/src/main/java/org/todayreading/collectingworker/naver/application/job/NaverCollectJobRunner.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/application/job/NaverCollectJobRunner.java
@@ -9,7 +9,7 @@ import org.springframework.stereotype.Service;
 import org.todayreading.collectingworker.naver.application.service.NaverCollectService;
 
 /**
- * 네이버 도서 수집 배치(full/daily)를 비동기로 실행하기 위한 잡 실행기입니다.
+ * 네이버 도서 수집 배치(full)를 비동기로 실행하기 위한 잡 실행기입니다.
  *
  * <p>이 클래스는 HTTP 컨트롤러나 스케줄러에서 호출되며,
  * 실제 배치 유스케이스 로직은 {@link NaverCollectService}에 위임합니다.
@@ -43,34 +43,6 @@ public class NaverCollectJobRunner {
       log.info("Naver collect job completed. type=full elapsedMs={}", elapsed.toMillis() + "ms");
     } catch (Exception ex) {
       log.error("Async job failed: Naver full scan.", ex);
-    }
-  }
-
-  /**
-   * 네이버 도서 일일 스캔 배치를 비동기로 실행합니다.
-   *
-   * <p>{@code maxStart}가 {@code null}이면
-   * {@link NaverCollectService#dailyScanAndPublish()}를 호출하고,
-   * 명시된 값이 있으면 {@link NaverCollectService#dailyScanAndPublish()} (Integer)}를 호출합니다.</p>
-   *
-   * @param maxStart 일일 스캔에서 사용할 최대 start 값 (null 이면 설정값 사용)
-   * @author 박성준
-   * @since 1.0.0
-   */
-  @Async("naverBatchExecutor")
-  public void runDailyScanAsync(Integer maxStart) {
-    Instant startAt = Instant.now();
-    log.info("Naver collect job started. type=daily maxStart={}", maxStart);
-    try {
-      if (maxStart == null) {
-        naverCollectService.dailyScanAndPublish();
-      } else {
-        naverCollectService.dailyScanAndPublish(maxStart);
-      }
-      Duration elapsed = Duration.between(startAt, Instant.now());
-      log.info("Naver collect job completed. type=daily elapsedMs={} maxStart={}", elapsed.toMillis(), maxStart);
-    } catch (Exception ex) {
-      log.error("Async job failed: Naver daily scan. maxStart={}", maxStart, ex);
     }
   }
 }

--- a/src/main/java/org/todayreading/collectingworker/naver/application/job/NaverCollectScheduler.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/application/job/NaverCollectScheduler.java
@@ -5,13 +5,13 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 네이버 도서 일일 수집 배치를 스케줄링하기 위한 컴포넌트입니다.
+ * 네이버 도서 풀스캔 배치를 스케줄링하기 위한 컴포넌트입니다.
  *
- * <p>매일 새벽 2시에 {@link NaverCollectJobRunner}를 통해
- * 일일 스캔 배치를 비동기로 실행합니다.</p>
+ * <p>매일 새벽 1시에 {@link NaverCollectJobRunner}를 통해
+ * 풀스캔 배치를 비동기로 실행합니다.</p>
  *
- * <p>풀스캔(full scan)은 스케줄러에서 절대 호출하지 않으며,
- * 운영자가 수동으로 API를 호출할 때만 실행됩니다.</p>
+ * <p>수동 실행은 컨트롤러를 통해 계속 지원되며,
+ * 스케줄러는 매일 자동 풀스캔만 수행합니다.</p>
  *
  * @author 박성준
  * @since 1.0.0
@@ -23,11 +23,7 @@ public class NaverCollectScheduler {
   private final NaverCollectJobRunner jobRunner;
 
   /**
-   * 매일 새벽 2시에 일일 스캔 배치를 비동기로 실행합니다.
-   *
-   * <p>{@code maxStart} 값은 {@code null}로 전달하여,
-   * {@link org.todayreading.collectingworker.naver.application.service.NaverCollectService#dailyScanAndPublish()}
-   * 내부에서 설정값(daily-max-start)을 사용하도록 위임합니다.</p>
+   * 매일 새벽 1시에 풀스캔 배치를 비동기로 실행합니다.
    *
    * <p>실제 유스케이스 로직은 {@link NaverCollectJobRunner} 및
    * {@link org.todayreading.collectingworker.naver.application.service.NaverCollectService}에서
@@ -37,8 +33,8 @@ public class NaverCollectScheduler {
    * @since 1.0.0
    */
 //  @Scheduled(cron = "0 * * * * *") // 매 분 0초마다 (테스트용)
-  @Scheduled(cron = "0 0 2 * * *")
-  public void runDailyScanAt2AM() {
-    jobRunner.runDailyScanAsync(null);
+  @Scheduled(cron = "0 0 1 * * *")
+  public void runFullScanAt2AM() {
+    jobRunner.runFullScanAsync();
   }
 }

--- a/src/main/java/org/todayreading/collectingworker/naver/application/pattern/AsciiPatternGenerator.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/application/pattern/AsciiPatternGenerator.java
@@ -1,15 +1,11 @@
 package org.todayreading.collectingworker.naver.application.pattern;
 
-import java.time.DayOfWeek;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.IntStream;
 
 /**
  * 숫자(0~9)와 영문 소문자(a~z)에 대한 쿼리 패턴을 생성하는 유틸리티 클래스입니다.
- *
- * <p>풀스캔 시에는 전체 패턴을, 일일 스캔 시에는 요일별로 분배된
- * 일부 패턴만 반환하도록 구성됩니다.
  *
  * <p>이 클래스는 외부에서 직접 사용하기보다는
  * {@link QueryPatternGenerator}를 통해 사용됩니다.
@@ -18,64 +14,6 @@ import java.util.stream.IntStream;
  * @since 1.0.0
  */
 final class AsciiPatternGenerator {
-
-  /**
-   * 숫자(0~9)에 대한 요일별 인덱스 범위 테이블입니다.
-   *
-   * <p>{@link #fullScanPatterns()} 기준 인덱스:
-   * <ul>
-   *   <li>0~9: '0' ~ '9'</li>
-   * </ul>
-   *
-   * <p>dayIndex = {@link DayOfWeek#getValue()} - 1 (월=0, ..., 일=6) 을 사용합니다.</p>
-   *
-   * <ul>
-   *   <li>월(0): [0, 2)  → '0','1'</li>
-   *   <li>화(1): [2, 4)  → '2','3'</li>
-   *   <li>수(2): [4, 6)  → '4','5'</li>
-   *   <li>목(3): [6, 7)  → '6'</li>
-   *   <li>금(4): [7, 8)  → '7'</li>
-   *   <li>토(5): [8, 9)  → '8'</li>
-   *   <li>일(6): [9,10) → '9'</li>
-   * </ul>
-   */
-  private static final int[][] DIGIT_RANGES = {
-      {0, 2},  // MONDAY
-      {2, 4},  // TUESDAY
-      {4, 6},  // WEDNESDAY
-      {6, 7},  // THURSDAY
-      {7, 8},  // FRIDAY
-      {8, 9},  // SATURDAY
-      {9, 10}  // SUNDAY
-  };
-
-  /**
-   * 알파벳(a~z)에 대한 요일별 인덱스 범위 테이블입니다.
-   *
-   * <p>{@link #fullScanPatterns()} 기준 인덱스:
-   * <ul>
-   *   <li>10~35: 'a' ~ 'z'</li>
-   * </ul>
-   *
-   * <ul>
-   *   <li>월(0): [10,14) → a,b,c,d</li>
-   *   <li>화(1): [14,18) → e,f,g,h</li>
-   *   <li>수(2): [18,22) → i,j,k,l</li>
-   *   <li>목(3): [22,26) → m,n,o,p</li>
-   *   <li>금(4): [26,30) → q,r,s,t</li>
-   *   <li>토(5): [30,33) → u,v,w</li>
-   *   <li>일(6): [33,36) → x,y,z</li>
-   * </ul>
-   */
-  private static final int[][] ALPHA_RANGES = {
-      {10, 14},  // MONDAY
-      {14, 18},  // TUESDAY
-      {18, 22},  // WEDNESDAY
-      {22, 26},  // THURSDAY
-      {26, 30},  // FRIDAY
-      {30, 33},  // SATURDAY
-      {33, 36}   // SUNDAY
-  };
 
   private AsciiPatternGenerator() {
     // 인스턴스화 방지
@@ -110,29 +48,4 @@ final class AsciiPatternGenerator {
     return queries;
   }
 
-  /**
-   * 요일별로 일일 스캔에 사용할 숫자/알파벳 패턴을 분배합니다.
-   *
-   * <p>{@link #fullScanPatterns()}의 인덱스를 기준으로
-   * {@link #DIGIT_RANGES}, {@link #ALPHA_RANGES} 테이블에서
-   * 오늘 요일에 해당하는 구간만 선택하여 반환합니다.</p>
-   *
-   * @param dayOfWeek 기준 요일
-   * @return 해당 요일에 사용할 숫자/알파벳 패턴 리스트
-   * @author 박성준
-   * @since 1.0.0
-   */
-  static List<String> dailyPatterns(DayOfWeek dayOfWeek) {
-    List<String> ascii = fullScanPatterns();
-
-    int dayIndex = dayOfWeek.getValue() - 1; // MONDAY=1 → 0, ..., SUNDAY=7 → 6
-
-    int[] digitRange = DIGIT_RANGES[dayIndex];
-    List<String> result = new ArrayList<>(ascii.subList(digitRange[0], digitRange[1]));
-
-    int[] alphaRange = ALPHA_RANGES[dayIndex];
-    result.addAll(ascii.subList(alphaRange[0], alphaRange[1]));
-
-    return result;
-  }
 }

--- a/src/main/java/org/todayreading/collectingworker/naver/application/pattern/HangulChoseongPatternGenerator.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/application/pattern/HangulChoseongPatternGenerator.java
@@ -1,14 +1,10 @@
 package org.todayreading.collectingworker.naver.application.pattern;
 
-import java.time.DayOfWeek;
 import java.util.ArrayList;
 import java.util.List;
 
 /**
  * 한글 초성(가~하 구간)을 기반으로 쿼리 패턴을 생성하는 유틸리티 클래스입니다.
- *
- * <p>풀스캔 시에는 전체 초성 패턴을, 일일 스캔 시에는 요일별로 분배된
- * 일부 초성 패턴만 반환하도록 구성됩니다.
  *
  * <p>이 클래스는 외부에서 직접 사용하기보다는
  * {@link QueryPatternGenerator}를 통해 사용됩니다.
@@ -49,67 +45,4 @@ final class HangulChoseongPatternGenerator {
     return queries;
   }
 
-  /**
-   * 요일별로 일일 스캔에 사용할 한글 초성 패턴을 분배합니다.
-   *
-   * <p>{@link #fullScanPatterns()}의 인덱스를 기준으로 다음과 같이 분배합니다
-   * (총 19개 초성):
-   *
-   * <ul>
-   *   <li>월요일: index 0~2 (3개)</li>
-   *   <li>화요일: index 3~5 (3개)</li>
-   *   <li>수요일: index 6~8 (3개)</li>
-   *   <li>목요일: index 9~11 (3개)</li>
-   *   <li>금요일: index 12~14 (3개)</li>
-   *   <li>토요일: index 15~16 (2개)</li>
-   *   <li>일요일: index 17~18 (2개)</li>
-   * </ul>
-   *
-   * @param dayOfWeek 기준 요일
-   * @return 해당 요일에 사용할 한글 초성 패턴 리스트
-   * @author 박성준
-   * @since 1.0.0
-   */
-  static List<String> dailyPatterns(DayOfWeek dayOfWeek) {
-    List<String> hangul = fullScanPatterns();
-    List<String> result = new ArrayList<>();
-
-    // hangul: index 0 ~ 18 (19개)
-    switch (dayOfWeek) {
-      case MONDAY -> result.addAll(subListSafe(hangul, 0, 3));
-      case TUESDAY -> result.addAll(subListSafe(hangul, 3, 6));
-      case WEDNESDAY -> result.addAll(subListSafe(hangul, 6, 9));
-      case THURSDAY -> result.addAll(subListSafe(hangul, 9, 12));
-      case FRIDAY -> result.addAll(subListSafe(hangul, 12, 15));
-      case SATURDAY -> result.addAll(subListSafe(hangul, 15, 17));
-      case SUNDAY -> result.addAll(subListSafe(hangul, 17, 19));
-    }
-
-    return result;
-  }
-
-  /**
-   * subList 요청 구간이 리스트 크기를 넘어가더라도
-   * IndexOutOfBoundsException이 발생하지 않도록 방어하는 헬퍼 메서드입니다.
-   * IndexOutOfBoundsException이란?
-   * from < 0 이거나
-   * to > size 이거나
-   * from > to 이면 전부 예외가 나는 exception
-   *
-   * @param source 원본 리스트
-   * @param fromIndex 시작 인덱스(포함)
-   * @param toIndex 끝 인덱스(배타)
-   * @return 유효 범위 내에서 잘려진 subList 결과
-   */
-  private static List<String> subListSafe(List<String> source, int fromIndex, int toIndex) {
-    int size = source.size();
-    if (fromIndex >= size) {
-      return List.of();
-    }
-    int safeToIndex = Math.min(toIndex, size);
-    if (fromIndex >= safeToIndex) {
-      return List.of();
-    }
-    return new ArrayList<>(source.subList(fromIndex, safeToIndex));
-  }
 }

--- a/src/main/java/org/todayreading/collectingworker/naver/application/pattern/QueryPatternGenerator.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/application/pattern/QueryPatternGenerator.java
@@ -1,7 +1,5 @@
 package org.todayreading.collectingworker.naver.application.pattern;
 
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -34,21 +32,4 @@ public final class QueryPatternGenerator {
     return List.copyOf(queries);
   }
 
-  /**
-   * 일일 스캔에 사용할 쿼리 패턴을 생성합니다.
-   *
-   * <p>오늘 날짜의 요일을 기준으로 숫자/알파벳/한글 초성 패턴을
-   * 요일별로 분배하여 일부만 반환합니다.</p>
-   *
-   * @return 오늘 요일에 해당하는 일일 스캔용 쿼리 문자열 목록
-   */
-  public static List<String> generateDailyScanQueries() {
-    DayOfWeek today = LocalDate.now().getDayOfWeek();
-
-    List<String> queries = new ArrayList<>();
-    queries.addAll(AsciiPatternGenerator.dailyPatterns(today));
-    queries.addAll(HangulChoseongPatternGenerator.dailyPatterns(today));
-
-    return List.copyOf(queries);
-  }
 }

--- a/src/main/java/org/todayreading/collectingworker/naver/application/service/NaverSearchInspectService.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/application/service/NaverSearchInspectService.java
@@ -13,7 +13,7 @@ import org.todayreading.collectingworker.naver.application.query.NaverQueryColle
  * 네이버 책 검색 API를 단건 조회하거나,
  * 특정 검색어에 대해 수집만 수행하는 보조/점검용 애플리케이션 서비스입니다.
  *
- * <p>이 서비스는 전체 풀스캔/일일 스캔 배치 파이프라인과는 별도로,
+ * <p>이 서비스는 전체 풀스캔 배치 파이프라인과는 별도로,
  * 다음과 같은 용도로 사용하는 것을 목표로 합니다.
  * <ul>
  *   <li>단일 페이지 조회로 네이버 API 응답을 직접 확인</li>

--- a/src/main/java/org/todayreading/collectingworker/naver/infrastructure/config/NaverApiProperties.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/infrastructure/config/NaverApiProperties.java
@@ -42,7 +42,6 @@ public record NaverApiProperties(
    * <ul>
    *   <li>{@code display} : 한 번의 요청에서 가져올 결과 개수 (1~100)</li>
    *   <li>{@code maxStart} : 풀스캔(full scan) 시 사용할 start 파라미터의 상한 값</li>
-   *   <li>{@code dailyMaxStart} : 일일 스캔(daily scan) 시 사용할 start 파라미터의 상한 값</li>
    *   <li>{@code sort} : 정렬 기준 (예: {@code sim}, {@code date})</li>
    *   <li>{@code requestIntervalMs} : 연속 호출 간 대기 시간(간격), 밀리초 단위</li>
    * </ul>
@@ -50,7 +49,6 @@ public record NaverApiProperties(
   public record SearchProperties(
       int display,          // naver.search.display
       int maxStart,         // naver.search.max-start
-      int dailyMaxStart,    // naver.search.daily-max-start
       String sort,          // naver.search.sort
       long requestIntervalMs // naver.search.request-interval-ms (연속 호출 간 간격, ms 단위)
   ) {

--- a/src/main/java/org/todayreading/collectingworker/naver/presentation/controller/NaverCollectBatchController.java
+++ b/src/main/java/org/todayreading/collectingworker/naver/presentation/controller/NaverCollectBatchController.java
@@ -4,7 +4,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.todayreading.collectingworker.naver.application.job.NaverCollectJobRunner;
 
@@ -44,23 +43,4 @@ public class NaverCollectBatchController {
     return ResponseEntity.accepted().build();
   }
 
-  /**
-   * 네이버 도서 일일 스캔 배치를 비동기로 실행합니다.
-   *
-   * <p>{@code maxStart} 파라미터가 없으면 설정값(daily-max-start)을 사용하고,
-   * 값이 지정된 경우 해당 최대 start 범위까지만 일일 스캔을 수행합니다.
-   * 요청은 배치 완료 여부와 관계없이 {@code 202 Accepted}를 즉시 반환합니다.</p>
-   *
-   * @param maxStart 일일 스캔에서 사용할 최대 start 값(옵션, null 허용)
-   * @return 수집 작업이 비동기로 접수되었음을 나타내는 HTTP 202 응답
-   * @author 박성준
-   * @since 1.0.0
-   */
-  @PostMapping("/daily-scan")
-  public ResponseEntity<Void> triggerDailyScan(
-      @RequestParam(name = "maxStart", required = false) Integer maxStart
-  ) {
-    jobRunner.runDailyScanAsync(maxStart);
-    return ResponseEntity.accepted().build();
-  }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -28,7 +28,6 @@ naver:
   search:
     display: 100           # 1요청당 최대 조회 건수(API 한번 호출 당 몇권씩 가져올래?)
     max-start: 1000        # full-scan 상한 (네이버 API start 최대 1000)
-    daily-max-start: 301   # daily-scan 상한
     sort: date             # 또는 sim
     request-interval-ms: 300   # 네이버 API 호출 간 최소 지연(ms)
   kafka:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정 및 정리**
  * 일일 스캔 기능이 제거되었습니다. 전체 배치 스캔만 지원됩니다.
  * 자동 스캔 예약 시간이 오전 2시에서 오전 1시로 변경되었습니다.
  * 일일 스캔 API 엔드포인트가 제거되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->